### PR TITLE
Using the 2015-2017 mortality rates instead of clusters to find the correlation between social determinants and mortality

### DIFF
--- a/app.R
+++ b/app.R
@@ -513,9 +513,37 @@ server <- function(input, output) {
     
   })
   
+  mort.rate <- reactive({
+    if(input$state_choice == "United States"){
+      cdc.data %>% dplyr::filter(
+        death_cause == input$death_cause,
+        #state_abbr == input$state_choice,
+        period == "2015-2017"
+      ) %>%
+        dplyr::mutate(
+          death_rate = death_num / population * 10^5
+          #death_rate = cut(death_rate, bin.geo.mort("Despair"))
+        ) %>%
+        dplyr::select(county_fips, death_rate)
+    }else {
+      cdc.data %>% dplyr::filter(
+        death_cause == input$death_cause,
+        state_abbr == input$state_choice,
+        period == "2015-2017"
+      ) %>%
+        dplyr::mutate(
+          death_rate = death_num / population * 10^5
+          #death_rate = cut(death_rate, bin.geo.mort("Despair"))
+        ) %>%
+        dplyr::select(county_fips, death_rate)
+    }
+  })
+  
   # Kendall Correlation Between Raw Mort Rate and CHR-SD
   output$page1.bar.cor1 <- renderPlot({
-    kendall.cor <- kendall.func(mort.cluster.ord(), chr.data.2019)
+
+    #kendall.cor <- kendall.func(mort.cluster.ord(), chr.data.2019)
+    kendall.cor <- kendall.func(mort.rate(), chr.data.2019)
     
     kendall.cor %>%
       dplyr::mutate(

--- a/init/Analyzer_Correlation.R
+++ b/init/Analyzer_Correlation.R
@@ -9,8 +9,8 @@ kendall.func <- function(x.data, sd.data) {
   align <- dplyr::left_join(x.data, sd.data, by = "county_fips") %>% 
     dplyr::select(-dplyr::one_of(c("county_fips", "state_name", "county_name")))
   
-  x <- as.numeric(dplyr::pull(align, cluster))
-  sd <- dplyr::select(align, -cluster)
+  x <- as.numeric(dplyr::pull(align, death_rate))
+  sd <- dplyr::select(align, -death_rate)
   
   cor.res <- list()
   for (n in names(sd)) {


### PR DESCRIPTION
Determining the correlation between social determinants and mortality using the 2015-2017 mortality rates instead of using clusters.