### PR TITLE
fix for county_highlight

### DIFF
--- a/app.R
+++ b/app.R
@@ -1875,7 +1875,17 @@ server <- function(input, output, session) {
     
     county_indices <- which(state_map@data$NAME %in% c(county_name))
     
-    if (length(county_indices) == 1){
+    if (length(county_indices) == 0){
+      for (current_polygons in state_map@polygons){
+        for (current_polygon in current_polygons@Polygons){
+          current_coords <- current_polygon@coords
+          if (sp::point.in.polygon(c(event$lng), c(event$lat), current_coords[,1], current_coords[,2])){
+            polygon = current_polygons
+            break
+          }
+        }
+      }
+    }else if (length(county_indices) == 1){
       polygon <- state_map@polygons[[county_indices[[1]]]]
     } else {
       for (index in county_indices){


### PR DESCRIPTION
It could be concluded that there are 3 sets of county names that live in the app right now. 
    - the one used for layerId when plotting
    - cdc.data
    - shapes file

what this fix include:
- Click on Alaskan counties will highlight the county correctly
- I am reasonably confident with the fix because it simply checks which polygon(s) is the click in when no county name matches the layerId
- So the county name discrepancy between layerId and shapes file is bypassed

what this fix does not include
- The mortality trend plot might break for some counties (southeastern Alaska). The root cause is that even the county names in cdc data and the ones we use for layerId are not consistent. 
- Unless we reconcile the discrepancies between the first two, I could not fix the trend plot issue. 
- Reasoning for the previous point:
   One example of the problem is stated as following,
   There is one county with layerId (label) "Petersburg Census Area" in Alaska. To plot the trend, we need to find the county in cdc.data. Yet, there are 2 counties with similar names in Alaska in cdc.data, "Petersburg Borough/Census Area" and "Wrangell-Petersburg Census Area". As a human being, I can't tell which one to use, so I do not expect my code to know it.