### PR TITLE
Fixes error when generating text about a determinant's correlation 

### DIFF
--- a/app.R
+++ b/app.R
@@ -1336,6 +1336,10 @@ server <- function(input, output, session) {
   })
   
   output$determinant_corr <- renderText({
+    if (nrow(kendall.cor()[kendall.cor()$chr_code == input$determinant_choice,]) == 0) {
+      return("")
+    }
+    
     if (kendall.cor()[kendall.cor()$chr_code == input$determinant_choice,]$kendall_cor >= 0) {
       return(paste0("Kendal Correlation with ",
                     input$death_cause,
@@ -1353,6 +1357,10 @@ server <- function(input, output, session) {
   })
   
   output$determinant_dir <- renderText({
+    if (nrow(kendall.cor()[kendall.cor()$chr_code == input$determinant_choice,]) == 0) {
+      return("")
+    }
+    
     if (kendall.cor()[kendall.cor()$chr_code == input$determinant_choice,]$kendall_p > .05) {
       return(paste0("<strong>No</strong> statistically significant ",
                     " relationship with mortality (p-value = ",


### PR DESCRIPTION
If kendal.cor() does not produce a correlation value for a given determinant, then the determinant info section will not display correlation or p-value text