### PR TITLE
This will give an error message if the datatframe for the boxplot is …

### DIFF
--- a/app.R
+++ b/app.R
@@ -1125,7 +1125,12 @@ server <- function(input, output, session) {
       dplyr::inner_join(geo.namemap, by = "county_fips") %>% 
       tidyr::drop_na()
     
-    if (nrow(sd.select) <= 6){
+    if (nrow(sd.select) == 0) {
+      
+      ggplot() + 
+        ggtitle("Error: sd.select is empty. Aborting boxplot creation.")
+      
+    } else if (nrow(sd.select) <= 6){
       
       ggplot(sd.select, aes(x = cluster, y = VAR, fill = cluster)) + 
         geom_boxplot() +


### PR DESCRIPTION
I looked into the issue with Hawaii not having a boxplot. This will thrown an error if sd.select (data for boxplot) is empty. 

Note: This does not fix the issue, but does give a more helpful error message if something goes wrong for all 50 states.